### PR TITLE
Metadata to tracking field

### DIFF
--- a/docs/source/training-configuration.rst
+++ b/docs/source/training-configuration.rst
@@ -8,7 +8,6 @@ Gymnos allows you to configure and train powerful models without writing a singl
 
 To run an experiment, the following keys are available:
 
-    - ``"experiment"``: defines name and description of the experiment
     - ``"dataset"``: defines the dataset with the associated preprocessing
     - ``"model"``:  defines the model
     - ``"training"``: defines training parameters
@@ -19,9 +18,6 @@ Each key is associated with a Python instance that builds the Python objects fro
 .. image:: images/gymnos-training-config.png
    :width: 100%
 
-Experiment
-==========
-.. autoclass:: lib.core.experiment.Experiment
 
 Dataset
 ==========

--- a/src/config/preferences.json
+++ b/src/config/preferences.json
@@ -39,8 +39,6 @@
     "executions_dir": "trainings/{dataset_name}/executions",
     // Directory to store tracking artifacts generated from trainings. Available formats: dataset_name, model_name, uuid, datetime
     "trackings_dir": "trainings/{dataset_name}/trackings",
-    // The default experiment name if you don't provide one. Available formats: dataset_name, model_name, uuid, datetime
-    "default_experiment_name": "{uuid}",
 
     // Whether or not save trained model to execution directory 
     "save_trained_model": true,

--- a/src/experiments/examples/boston_housing.json
+++ b/src/experiments/examples/boston_housing.json
@@ -37,9 +37,6 @@
         "validation_split": 0.25
     },
     "tracking": {
-        "additional_params": {
-            "device": "cpu"
-        },
         "trackers": [
             {
                 "type": "tensorboard"

--- a/src/experiments/examples/dogs_vs_cats.json
+++ b/src/experiments/examples/dogs_vs_cats.json
@@ -36,12 +36,6 @@
         "epochs": 5
     },
     "tracking": {
-        "log_model_params": true, 
-        "log_model_metrics": true, 
-        "log_training_params": true, 
-        "additional_params": { 
-
-        },
         "trackers": [ 
             {
                 "type": "tensorboard"

--- a/src/experiments/examples/dogs_vs_cats.json
+++ b/src/experiments/examples/dogs_vs_cats.json
@@ -1,11 +1,4 @@
 {
-    "experiment": {
-        "name": null, 
-        "description": null, 
-        "tags": [ 
-
-        ]
-    },
     "dataset": {
         "name": "dogs_vs_cats", 
         "samples": {  

--- a/src/experiments/telefonica/data_usage_test.json
+++ b/src/experiments/telefonica/data_usage_test.json
@@ -4,7 +4,6 @@
          "tags": ["temporal-series", "forecasting"]
     },
     "model": {
-        "description": "Prediction for one serie of web traffic",
         "name": "data_usage_holt_winters"
     },
     "dataset": {

--- a/src/experiments/telefonica/data_usage_test.json
+++ b/src/experiments/telefonica/data_usage_test.json
@@ -1,8 +1,4 @@
 {
-    "experiment": {
-         "name": "Data Usage Test",
-         "tags": ["temporal-series", "forecasting"]
-    },
     "model": {
         "name": "data_usage_holt_winters"
     },

--- a/src/experiments/telefonica/mte.json
+++ b/src/experiments/telefonica/mte.json
@@ -1,8 +1,4 @@
 {
-    "experiment": {
-        "name": "Media Tagging Engine",
-        "tags": ["mte", "network"]
-    },
     "model": {
         "name": "mte_nn",
         "parameters": {

--- a/src/experiments/telefonica/mte.json
+++ b/src/experiments/telefonica/mte.json
@@ -4,7 +4,6 @@
         "tags": ["mte", "network"]
     },
     "model": {
-        "description": "Media Tagging Engine Subscription Classifier",
         "name": "mte_nn",
         "parameters": {
             "input_shape": [20000]

--- a/src/experiments/telefonica/unusual_data_usage_test.json
+++ b/src/experiments/telefonica/unusual_data_usage_test.json
@@ -7,7 +7,6 @@
         ]
     },
     "model": {
-        "description": "Anomaly detection for one serie of web traffic",
         "name": "unusual_data_usage_weighted_thresholds"
     },
     "dataset": {

--- a/src/experiments/telefonica/unusual_data_usage_test.json
+++ b/src/experiments/telefonica/unusual_data_usage_test.json
@@ -1,11 +1,4 @@
 {
-    "experiment": {
-        "name": "Data Usage Test",
-        "tags": [
-            "temporal-series",
-            "anomaly-detection"
-        ]
-    },
     "model": {
         "name": "unusual_data_usage_weighted_thresholds"
     },

--- a/src/experiments/tests/boston_housing.json
+++ b/src/experiments/tests/boston_housing.json
@@ -31,6 +31,9 @@
         "validation_split": 0.2
     },
     "tracking": {
+        "tags": {
+            "training_type": "regression_test"
+        },
         "trackers": [
             {
                 "type": "tensorboard"

--- a/src/experiments/tests/mte.json
+++ b/src/experiments/tests/mte.json
@@ -1,7 +1,4 @@
 {
-    "experiment": {
-        "tags": ["mte", "network"]
-    },
     "model": {
         "name": "mte_nn",
         "parameters": {

--- a/src/experiments/tests/mte.json
+++ b/src/experiments/tests/mte.json
@@ -3,7 +3,6 @@
         "tags": ["mte", "network"]
     },
     "model": {
-        "description": "Media Tagging Engine Subscription Classifier",
         "name": "mte_nn",
         "parameters": {
             "input_shape": [7]

--- a/src/experiments/tests/rock_paper_scissors.json
+++ b/src/experiments/tests/rock_paper_scissors.json
@@ -42,6 +42,9 @@
         ]
     },
     "tracking": {
+        "tags": {
+            "training_type": "regression_test"
+        },
         "trackers": [
             {
                 "type": "tensorboard"

--- a/src/lib/core/dataset.py
+++ b/src/lib/core/dataset.py
@@ -46,6 +46,7 @@ class Dataset:
         - ``"mte"``: :class:`lib.datasets.mte.MTE`,
         - ``"data_usage_test"``: :class:`lib.datasets.data_usage_test.DataUsageTest`,
         - ``"unusual_data_usage_test"``: :class:`lib.datasets.unusual_data_usage_test.UnusualDataUsageTest`
+        - ``"rock_paper_scissors"``: :class:`lib.datasets.rock_paper_scissors.RockPaperScissors`
 
     samples: dict, optional
         Samples to split dataset into random train and test subsets
@@ -53,20 +54,17 @@ class Dataset:
         The following properties are available:
 
         **train**: `float` or `int`, optional
-            If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to
-            include in the train split.
+            If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the train split.
             If int, represents the absolute number of train samples.
             If None, the value is automatically set to the complement of the test size.
         **test**: `float` or `int`, optional
-            If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to
-            include in the test split.
+            If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the test split.
             If int, represents the absolute number of test samples.
             If None, the value is set to the complement of the train size.
             If None and ``train_size`` is unspecified, by default the value is set to 0.25.
     preprocessors: list of dict, optional
         List of preprocessors to apply to dataset. This property requires a list with dictionnaries with at least
-        a ``type`` field specifying the type of preprocessor.  The other properties are the properties for that
-        preprocessor.
+        a ``type`` field specifying the type of preprocessor.  The other properties are the properties for that preprocessor.
 
         The current available preprocessors are the following:
 

--- a/src/lib/core/model.py
+++ b/src/lib/core/model.py
@@ -32,8 +32,6 @@ class Model:
         - ``"mte_nn"``: :class:`lib.models.mte_nn.MTENN`
     parameters: dict, optional
         Parameters associated with the model
-    description: str, optional
-        Optional description of the model
     Examples
     --------
 
@@ -41,7 +39,6 @@ class Model:
 
         Model(
             name="data_usage_holt_winters",
-            description="Holt Winters with low parameters",
             parameters={
                 "beta": 0.029,
                 "alpha": 0.5
@@ -49,12 +46,11 @@ class Model:
         )
     """  # noqa: E501
 
-    def __init__(self, name, parameters=None, description=None):
+    def __init__(self, name, parameters=None):
         parameters = parameters or {}
 
         self.name = name
         self.parameters = parameters
-        self.description = description
 
         logger.debug("Importing model {}".format(name))
         ModelClass = import_from_json(MODELS_IDS_TO_MODULES_PATH, name)

--- a/src/lib/core/tracking.py
+++ b/src/lib/core/tracking.py
@@ -5,6 +5,7 @@
 #
 
 import os
+import uuid
 import logging
 
 from ..trackers import TrackerList
@@ -20,6 +21,10 @@ class Tracking:
     """
     Parameters
     ----------
+    run_id: str, optional
+        ID of the run to log under. If not provided, it will be a random UUID
+    tags: list of str, optional
+        Tags for current run.
     log_model_params: bool, optional
         Whether or not log model parameters
     log_model_metrics: bool, optional
@@ -28,8 +33,7 @@ class Tracking:
         Whether or not log training params.
     trackers: list of dict, optional
         List of trackers to log parameters and metrics. This property requires a list with dictionnaries with at least
-        a ``type`` field specifying the type of tracker. The other properties are the properties for that
-        tracker.
+        a ``type`` field specifying the type of tracker. The other properties are the arguments for the constructor of that tracker.
 
         The current available trackers are the following:
 
@@ -61,16 +65,20 @@ class Tracking:
                 data_scientist="Rubén Salas"
             }
         )
-    """
+    """ # noqa: E501
 
-    def __init__(self, log_model_params=True, log_model_metrics=True, log_training_params=True, trackers=None,
-                 additional_params=None):
+    def __init__(self, run_id=None, tags=None, log_model_params=True, log_model_metrics=True, log_training_params=True,
+                 trackers=None):
         trackers = trackers or []
 
+        if run_id is None:
+            run_id = uuid.uuid4().hex
+
+        self.tags = tags or []
+        self.run_id = run_id
         self.log_model_params = log_model_params
         self.log_model_metrics = log_model_metrics
         self.log_training_params = log_training_params
-        self.additional_params = additional_params or {}
 
         logger.debug("Import {} trackers".format(len(trackers)))
         self.trackers = TrackerList()

--- a/src/lib/core/tracking.py
+++ b/src/lib/core/tracking.py
@@ -23,8 +23,8 @@ class Tracking:
     ----------
     run_id: str, optional
         ID of the run to log under. If not provided, it will be a random UUID
-    tags: list of str, optional
-        Tags for current run.
+    tags: dict, optional
+        Tags for current run. The keys will be the tag names and the values will be the tag values.
     log_model_params: bool, optional
         Whether or not log model parameters
     log_model_metrics: bool, optional
@@ -41,14 +41,14 @@ class Tracking:
             - ``"mlflow"``: :class:`lib.trackers.mlflow.MLFlow`,
             - ``"tensorboard"``: :class:`lib.trackers.tensorboard.Tensorboard`
 
-    additional_params: dict, optional
-        Additional parameters to log
-
     Examples
     --------
     .. code-block:: py
 
         Tracking(
+            tags={
+                "user": "John Doe"
+            },
             log_model_params=True,
             log_model_metrics=True,
             log_training_metrics=False,
@@ -60,10 +60,7 @@ class Tracking:
                 {
                     "type": "tensorboard"
                 }
-            ],
-            additional_params={
-                data_scientist="Rubén Salas"
-            }
+            ]
         )
     """ # noqa: E501
 
@@ -74,7 +71,7 @@ class Tracking:
         if run_id is None:
             run_id = uuid.uuid4().hex
 
-        self.tags = tags or []
+        self.tags = tags or {}
         self.run_id = run_id
         self.log_model_params = log_model_params
         self.log_model_metrics = log_model_metrics

--- a/src/lib/trackers/comet_ml.py
+++ b/src/lib/trackers/comet_ml.py
@@ -36,8 +36,8 @@ class CometML(Tracker):
                                      log_git_metadata=False, log_git_patch=False)
         self.experiment.set_name(run_name)
 
-    def add_tag(self, tag):
-        self.experiment.add_tag(tag)
+    def log_tag(self, key, value):
+        self.experiment.add_tag("{}__{}".format(key, value))
 
 
     def log_asset(self, name, file_path):

--- a/src/lib/trackers/history.py
+++ b/src/lib/trackers/history.py
@@ -18,15 +18,15 @@ class History(Tracker):
 
         self.start_datetime = datetime.now()
 
-        self.tags = []
+        self.tags = {}
         self.params = {}
         self.assets = {}
         self.images = {}
         self.figures = {}
         self.metrics = defaultdict(list)
 
-    def add_tag(self, tag):
-        self.tags.append(tag)
+    def log_tag(self, key, value):
+        self.tags[key] = value
 
     def log_asset(self, name, file_path):
         self.assets[name] = file_path

--- a/src/lib/trackers/mlflow.py
+++ b/src/lib/trackers/mlflow.py
@@ -31,8 +31,8 @@ class MLFlow(Tracker):
         mlflow.set_tracking_uri(os.path.join(logdir, "mlruns"))
         mlflow.start_run(run_name=run_name, experiment_id=self.experiment_id)
 
-    def add_tag(self, tag):
-        pass
+    def log_tag(self, key, value):
+        mlflow.set_tag(key, value)
 
     def log_metric(self, name, value, step=None):
         mlflow.log_metric(name, value)

--- a/src/lib/trackers/tensorboard.py
+++ b/src/lib/trackers/tensorboard.py
@@ -23,7 +23,7 @@ class Tensorboard(Tracker):
     def start(self, run_name, logdir):
         self.writer = tf.summary.FileWriter(os.path.join(logdir, "tensorboard", run_name))
 
-    def add_tag(self, tag):
+    def log_tag(self, key, value):
         pass
 
     def log_asset(self, name, file_path):

--- a/src/lib/trainer.py
+++ b/src/lib/trainer.py
@@ -112,13 +112,13 @@ class Trainer:
 
         # LOG PARAMETERS
 
-        tracking.trackers.log_params(model.parameters)
-        tracking.trackers.log_params(tracking.additional_params)
         if tracking.log_model_params:
             tracking.trackers.log_params(model.parameters)
 
         if tracking.log_training_params:
             tracking.trackers.log_params(training.parameters)
+
+        tracking.trackers.log_tags(tracking.tags)
 
         for model_param_name, model_param_value in training.parameters.items():
             str_model_param_value = str(model_param_value)


### PR DESCRIPTION
This PR includes:
- Move experiment fields to tracking (closes #112)
- Tags as key-value pair, i.e {tag-name: tag-value}, e.g {ml_field: "computer_vision"}