### PR TITLE
Update references to new docs with ReadTheDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ For instance, to run a configuration for [Dogs vs. Cats dataset](https://www.kag
 $ gymnos train examples/experiments/dogs_vs_cats.json
 ```
 
-For more information check out [Gymnos documentation](http://dev-aura-comp-01:8081).
+For more information check out [Gymnos documentation](http://dev-aura-comp-01/docs/gymnos/en/latest/).
 
 ## Development
 Gymnos is still under development. Contributions are always welcome!.

--- a/azure-pipelines.docker.yml
+++ b/azure-pipelines.docker.yml
@@ -17,13 +17,9 @@ pool:
 
 steps:
 - script: |
-    echo Generate documentation
-    python3.6 -m pip install sphinx sphinx-rtd-theme sphinx-argparse flask numpy --user
-    sphinx-build -b html docs/source docs/build
-    sudo systemctl stop gymnos_rtd
-    cp -r docs/build $(gymnosRTDPath)
-    sudo systemctl start gymnos_rtd
-  displayName: 'Generate documentation'
+    echo Update documentation
+    docker exec self-hosted-readthedocs_web_1 python manage.py update_repos --slug gymnos
+  displayName: 'Update documentation'
   condition: ne(variables['Build.Reason'], 'PullRequest')
 - script: |
     echo Validate documentation


### PR DESCRIPTION
Update references to new docs with our own ReadTheDocs and update docs with each commit to master (Azure Pipelines)
@kawaits please update link for new docs url in repo details (text next to "A training platform for AI models") :globe_with_meridians: ->  http://dev-aura-comp-01/docs/gymnos/en/latest/